### PR TITLE
Improve answer options display with letter buttons

### DIFF
--- a/src/lessons/lesson_handler.py
+++ b/src/lessons/lesson_handler.py
@@ -146,15 +146,24 @@ async def send_question(message: Message, state: FSMContext):
     
     question = questions[current_idx]
     
-    # Create keyboard with options
+    # Create keyboard with letter options (A, B, C, D)
     builder = InlineKeyboardBuilder()
-    for i, option in enumerate(question["options"]):
-        builder.button(text=option, callback_data=f"option_{i}")
+    letters = ['A', 'B', 'C', 'D']
+    for i, _ in enumerate(question["options"]):
+        if i < len(letters):
+            builder.button(text=letters[i], callback_data=f"option_{i}")
     
-    # Send question
+    # Format options with letters
+    options_text = ""
+    for i, option in enumerate(question["options"]):
+        if i < len(letters):
+            options_text += f"{letters[i]}. {option}\n"
+    
+    # Send question with options in the message
     await message.answer(
         f"Вопрос {current_idx + 1} из {len(questions)}:\n\n"
-        f"{question['text']}",
+        f"{question['text']}\n\n"
+        f"{options_text}",
         reply_markup=builder.as_markup()
     )
 
@@ -187,11 +196,14 @@ async def process_practice_answer(callback: CallbackQuery, state: FSMContext):
     await state.update_data(data)
     
     # Send feedback
+    letters = ['A', 'B', 'C', 'D']
     if is_correct:
         await callback.message.answer("✅ Правильно!")
     else:
-        correct_option = question["options"][question["correct_index"]]
-        await callback.message.answer(f"❌ Неправильно. Правильный ответ: {correct_option}")
+        correct_idx = question["correct_index"]
+        correct_letter = letters[correct_idx] if correct_idx < len(letters) else ""
+        correct_option = question["options"][correct_idx]
+        await callback.message.answer(f"❌ Неправильно. Правильный ответ: {correct_letter}. {correct_option}")
     
     # Send the next question
     await send_question(callback.message, state)

--- a/src/lessons/test_handler.py
+++ b/src/lessons/test_handler.py
@@ -102,15 +102,24 @@ async def send_question(message: Message, user_id: int):
     
     question = test_data["questions"][current_idx]
     
-    # Create keyboard with options
+    # Create keyboard with letter options (A, B, C, D)
     builder = InlineKeyboardBuilder()
-    for i, option in enumerate(question["options"]):
-        builder.button(text=option, callback_data=f"answer_{i}")
+    letters = ['A', 'B', 'C', 'D']
+    for i, _ in enumerate(question["options"]):
+        if i < len(letters):
+            builder.button(text=letters[i], callback_data=f"answer_{i}")
     
-    # Send question
+    # Format options with letters
+    options_text = ""
+    for i, option in enumerate(question["options"]):
+        if i < len(letters):
+            options_text += f"{letters[i]}. {option}\n"
+    
+    # Send question with options in the message
     await message.answer(
         f"Вопрос {current_idx + 1} из {len(test_data['questions'])}:\n\n"
-        f"{question['text']}",
+        f"{question['text']}\n\n"
+        f"{options_text}",
         reply_markup=builder.as_markup()
     )
 
@@ -153,11 +162,14 @@ async def process_answer(callback: CallbackQuery, state: FSMContext):
     test_data["current_question"] += 1
     
     # Send feedback
+    letters = ['A', 'B', 'C', 'D']
     if selected_option == question["correct_index"]:
         await callback.message.answer("✅ Правильно!")
     else:
-        correct_option = question["options"][question["correct_index"]]
-        await callback.message.answer(f"❌ Неправильно. Правильный ответ: {correct_option}")
+        correct_idx = question["correct_index"]
+        correct_letter = letters[correct_idx] if correct_idx < len(letters) else ""
+        correct_option = question["options"][correct_idx]
+        await callback.message.answer(f"❌ Неправильно. Правильный ответ: {correct_letter}. {correct_option}")
     
     # Send the next question
     await send_question(callback.message, user_id)


### PR DESCRIPTION
## Changes

This PR improves the display of answer options in both the lesson practice questions and diagnostic test questions by:

1. Displaying the full text of answer options in the message body
2. Using letter buttons (A, B, C, D) instead of full text on buttons
3. Updating feedback messages to include the letter of the correct answer

## Problem Solved

Long answer options were not fitting on the buttons, making them difficult to read. This change improves readability by:
- Showing the full text of each option in the message
- Using simple letter buttons that always fit
- Maintaining the same functionality while improving the user experience

## Testing

The changes have been tested and verified to work correctly with the existing question format.

## Screenshots

N/A - Visual changes will be apparent in the Telegram bot interface.

@andrewmalov can click here to [continue refining the PR](https://app.all-hands.dev/conversations/becdc6fb470940ef918a7d032869b8c3)